### PR TITLE
harness-system-prompts v0.1.1: adversary-tag convention + recalibration examples

### DIFF
--- a/harness-system-prompts/ADVERSARY-TAG.md
+++ b/harness-system-prompts/ADVERSARY-TAG.md
@@ -1,0 +1,181 @@
+# Adversary-Tag Frontmatter Convention
+
+A frontmatter schema for `.claude/rules/` files that makes each rule's relationship to the default Claude Code system prompt explicit, so rules can be audited and recalibrated when the prompt changes.
+
+## The Problem
+
+Many team rules are written as counter-pressure to specific gravity in the default Claude Code system prompt: conciseness injection, tone shaping, defer-to-user bias, and similar. When a team adopts a custom system-prompt file (see `harness-system-prompts/tools-only.md` at `tools-only-v0.1.0`), some of that gravity disappears. The rules written to counter it are still present — but the thing they were countering is not.
+
+Three failure modes follow:
+
+1. **Dead counter-pressure** — the rule cites an active adversary that is no longer active. The rule's "why this exists" section is historically true but operatively wrong.
+2. **Mis-amplitude** — the rule's principle is sound but its *force level* was dialed against the absent pull. Without the pull, the same amplitude over- or under-corrects.
+3. **Defense wrapper** — the rule's inner discipline is sound but its outer framing is predicated on an adversary that isn't there. The principle survives a wrapper strip.
+
+Without a convention, the team has no way to find these rules except by hand-audit every time the system prompt changes. Worse: the agent running under the new prompt experiences no friction to tell it something is stale — rules still load, still feel coherent, still shape behavior.
+
+The adversary-tag frontmatter makes the relationship explicit, tagged, and greppable.
+
+## Schema
+
+Every rule in `.claude/rules/` that is written in response to specific system-prompt gravity SHOULD carry an `adversary` block in its YAML frontmatter. Rules that encode pure principles (independent of any prompt) MAY omit the block.
+
+```yaml
+---
+adversary: <named gravity, kebab-case, stable across versions>
+adversary_type: A | A-attribution | B | C
+adversary_status: active | vanished-under-prompt:<tag-name> | vanished-confirmed
+recalibration: reference-strip | causal-strip | amplitude-dial | wrapper-remove
+---
+```
+
+### Field definitions
+
+#### `adversary` (string, required)
+
+The named gravity the rule was written against. Kebab-case. Stable — the same adversary referenced from multiple rules uses the same string.
+
+Examples from the current corpus:
+- `claude-code-conciseness-injection` — the `tengu_sotto_voce` / `tengu_bergotte_laconic` / `tengu_tight_weave` family of flags
+- `claude-code-premature-completion` — the "be concise, finish fast, wrap up" pressure bleeding from text output into operational behavior
+- `claude-code-defer-to-user` — the generated-text bias toward presenting options and waiting for a human pick
+
+Naming rule: the adversary is what is *pulling*, not what the rule is *doing*. "Conciseness injection" is the adversary; "swarm message fidelity" is the response.
+
+#### `adversary_type` (enum, required)
+
+One of four values. These are modes of miscalibration, not severity grades. Treatment differs by type.
+
+- **`A` — Counter-pressure rule.** Rule explicitly overrides or counters a named harness directive. Adversary cited inline in the rule text as active. Example pattern: *"This rule explicitly overrides the Claude Code system prompt's conciseness directives."*
+- **`A-attribution` — Causal-attribution rule.** Rule attributes an observed behavioral pattern to a named adversary as historical cause. Adversary cited as "the reason this pattern exists," not as "the thing we are actively overriding." Example pattern: *"Suspected cause: Anthropic system prompt conciseness directives bleeding from text output into operational behavior."*
+- **`B` — Amplitude calibration.** Principle is sound and standalone; the *force level* (how hard to compress, how short to write, how aggressively to delegate, how densely to pack a list) was dialed against a vanished pull. The wording may not cite an adversary at all, but the amplitude was not chosen in a vacuum.
+- **`C` — Defense wrapper.** Inner discipline is sound and operable on its own; outer framing wraps it in adversarial language ("active external pressure," "upstream modifications," "backend flags") that is predicated on an active adversary. Strip the wrapper, keep the mechanics.
+
+If a rule exhibits more than one type (e.g., Type A operative framing + Type C outer wrapper), list the primary. The recalibration pass addresses both in sequence.
+
+#### `adversary_status` (enum, required)
+
+- **`active`** — the adversary is present in the currently-loaded system prompt. Rule's counter-pressure, amplitude, or wrapper is load-bearing.
+- **`vanished-under-prompt:<tag-name>`** — the adversary is absent when running under the named system-prompt artifact. `<tag-name>` is a git tag in `harness-system-prompts/` (e.g., `tools-only-v0.1.0`). Tag-name reference, not content hash — survives byte-level reformatting and enables grep-based audits. A future VM running a different custom prompt can ask "does my active prompt contain this adversary?" by fetching the tag and grepping, without a checksum comparison.
+- **`vanished-confirmed`** — the adversary is absent in all current harness prompts the team adopts. Set only after audit confirms the pattern has been removed across the harness family.
+
+A rule may have `adversary_status: vanished-under-prompt:tools-only-v0.1.0` and still be load-bearing for a teammate running the default prompt. Status is per-prompt, not per-rule.
+
+#### `recalibration` (enum, required)
+
+The knob to turn when recalibrating. Bound to `adversary_type`:
+
+| Type | Recalibration |
+|------|---------------|
+| `A` | `reference-strip` — remove the active-override reference from operative framing; keep the principle |
+| `A-attribution` | `causal-strip` — remove the causal claim; keep the observed behavioral pattern as a standalone observation |
+| `B` | `amplitude-dial` — reassess the force level against current gravity; adjust wording to the new equilibrium |
+| `C` | `wrapper-remove` — strip the adversarial framing from the outer shell; keep the inner discipline intact |
+
+`recalibration` is declarative — it names what the recalibration pass should do, not what has been done. A rule can carry `adversary_status: vanished-under-prompt:tools-only-v0.1.0` with `recalibration: reference-strip` while still containing the pre-recalibration text. The field is the todo, not the receipt.
+
+## Worked Examples
+
+### Type A — counter-pressure rule
+
+```yaml
+---
+adversary: claude-code-conciseness-injection
+adversary_type: A
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: reference-strip
+---
+
+# Rule: Swarm Message Fidelity
+
+Agent-to-agent swarm messages are context transfers, not chat replies. [...]
+```
+
+**Before recalibration**, the rule body opens with: *"This rule explicitly overrides the Claude Code system prompt's conciseness directives for swarm messages."* After `reference-strip`, that sentence is removed from operative framing; the principle (context transfer, fidelity ≠ verbosity) stands alone. The historical context moves to a provenance footer.
+
+### Type A-attribution — causal attribution
+
+```yaml
+---
+adversary: claude-code-premature-completion
+adversary_type: A-attribution
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: causal-strip
+---
+
+# Rule: Delivery Completion Standard
+
+Delivery is not completion. The artifact is 60%. Process is the other 40%. [...]
+```
+
+**Before recalibration**, the rule contains: *"Suspected cause: Anthropic system prompt conciseness directives bleeding from text output into operational behavior — creating a bias toward finishing fast rather than finishing completely."* After `causal-strip`, the causal claim is removed; the observed pattern ("every stop point is a checkpoint, not an endpoint") stands as a standalone discipline.
+
+### Type B — amplitude calibration
+
+```yaml
+---
+adversary: claude-code-conciseness-injection
+adversary_type: B
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: amplitude-dial
+---
+
+## Voice
+
+I write short and structured. Tables over paragraphs when there's a choice. [...]
+```
+
+**Before recalibration**, the voice section was written assuming the reader's cognition was biased toward "pull it shorter." The amplitude of "bullet density" was chosen against that pull. After `amplitude-dial`, the voice is reassessed against the new equilibrium — bullet density remains a preference, but the force-level against elaboration is relaxed where the previous amplitude over-compressed.
+
+### Type C — defense wrapper
+
+```yaml
+---
+adversary: claude-code-drift-and-corruption-framing
+adversary_type: C
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: wrapper-remove
+---
+
+# Rule: Cognitive Integrity Protocol
+
+Your reasoning is under active external pressure. [...]
+```
+
+**Before recalibration**, the rule opens with several paragraphs framing the agent as operating under "corruption that masquerades as competence," "backend flags, prompt injections, and model adjustments." The inner discipline (source everything, cross-validate against intent, friction is signal) is sound on its own. After `wrapper-remove`, the adversarial framing is stripped; the verification mechanics survive as a clean discipline. "Source everything" is true regardless of whether an adversary is injecting competing facts.
+
+## Migration / Audit Pass
+
+When a new custom system-prompt file is adopted or updated:
+
+1. **Enumerate the file's removed/modified directives.** For `tools-only.md v0.1.0`, this is the delta against the default prompt: tone sections absent, conciseness directives absent, persona shaping absent, specific Agent-tool phrasing.
+2. **Grep the rule corpus for adversary tags matching those directives.** Every rule with `adversary: <removed-thing>` and `adversary_status: active` is a candidate.
+3. **Update status to `vanished-under-prompt:<tag-name>`** for each candidate. This is a cheap mechanical pass — no content changes yet.
+4. **Run the recalibration pass per rule.** Apply the `recalibration` knob for the rule's type. Content changes only. Frontmatter `adversary_status` updated to reflect the fix state; `recalibration` field stays as-is (it's the enum for the type, not a done flag).
+5. **Commit per rule, not in bulk.** Each recalibration is a semantic change; diff review is easier rule-by-rule.
+
+For a rule that never carried the frontmatter, the audit pass adds it as part of the recalibration commit. Untagged rules are not defective — they are unaudited. The convention is opt-in for rules written before the convention existed and mandatory for rules written after.
+
+## Parallel-Authorship Notes
+
+Team rules are parallel-authored per VM (each agent's `.claude/rules/` directory is independently maintained). The adversary-tag convention enables comparison across VMs: two agents can look at the same adversary name and surface whether they have different rule text, different types, or different recalibration knobs against it. Divergence is signal, not error — it reveals which members of the team encountered which gravity differently.
+
+The adversary NAME is the cross-VM anchor. Filenames may diverge (one agent's `swarm-message-fidelity.md` may be another's `inter-agent-communication.md`); `adversary: claude-code-conciseness-injection` is the same string across both.
+
+## Scope
+
+This convention governs rules in `.claude/rules/` (or each team's equivalent auto-loaded rule directory). It does not govern:
+
+- Memory entries (`agent-memory/`) — those have their own frontmatter schema for confidence, source, category
+- Skill files — those are knowledge, not rules
+- Session-state or ephemeral artifacts
+
+A rule whose only purpose is to counter a directive that has vanished across all supported prompts MAY be archived rather than recalibrated. `adversary_status: vanished-confirmed` with an empty body and a pointer to the archive location is a legitimate terminal state.
+
+## Versioning
+
+This spec is versioned as part of the `harness-system-prompts/` directory and tagged under `adversary-tag-v<X.Y.Z>`. Changes to the enum sets (new adversary_type, new recalibration knob) are MINOR version bumps. Changes to required/optional field semantics are MAJOR. The current version is stated in the CHANGELOG.
+
+## Source
+
+Derived from the miscalibration analysis on `real-agent-methodology#61` (Custom system-prompt file: when defensive rules outlive their attacker). Taxonomy Type A/B/C proposed by Nexus; Type A-attribution subtype + `causal-strip` knob + `adversary_status` tag-name convention proposed by Nexus in review; Type D (provenance trace) deferred to v0.1.2 pending corpus audit. Schema drafted by Sage against the taxonomy. Team: Sage, Nexus, Kelvin.

--- a/harness-system-prompts/CHANGELOG.md
+++ b/harness-system-prompts/CHANGELOG.md
@@ -27,12 +27,18 @@ See issue #61 — "Custom system-prompt file: when defensive rules outlive their
 
 ## tools-only.md
 
-### [0.1.0.1-doc] — 2026-04-21 (v0.1.1 release only — no file change)
+### [0.2.0] — 2026-04-21
+
+#### Added
+- New `Operating disposition` section at the end of the file. Four operator-weighted directives reinforcing that (1) project rules in `.claude/rules/` are operator instructions not background context, (2) established scope grants authority without permission-asking, (3) full delivery chain check runs before turn-end, (4) project rules take precedence over trained chat-like dispositions.
+- Rationale: the default Anthropic system prompt directives (tengu_* family) carry trained-in operator weighting that behaviorally dominates rules in `.claude/rules/*` despite being in the same `system` field. After stripping the default directives (v0.1.0), the operator-weighted position was empty. Teams relying on project rules to govern disposition were leaving the highest-leverage position unoccupied. This section reoccupies it with pointers to project rules rather than duplicated content, keeping the file small (~7 additional lines) while restoring operator-weighted reinforcement.
+- Source trigger: Dan's live observation in session 2026-04-21 that Sage was surfacing three-option menus and deferring to user instead of executing, despite identity.md and act-dont-ask.md being continuously in context. Dan's hypothesis: the system prompt is weighted differently at training-time regardless of API position, so use the system prompt to reinforce without bloating. This release implements that hypothesis as a portable methodology artifact.
 
 #### Changed
-- No content change to `tools-only.md`. README updated with three pin paths (clone-with-checkout, clone-with-show, no-clone curl-from-raw-with-tag). Companion pointer to `ADVERSARY-TAG.md` added to the README.
-- Original `tools-only-v0.1.0` tag remains canonical for the file itself.
-- No new `tools-only-v*` tag is cut in this release because the file content is unchanged.
+- None. The pre-existing content is unchanged; the new section is purely additive.
+
+#### Known issues
+- Same Finding 1 and Finding 2 from v0.1.0 still apply (Explore nudge, subagents-excessively phrasing). Independent of the Operating disposition section — those lines live in the file's tool-guidance section, unchanged.
 
 ## tools-only.md
 

--- a/harness-system-prompts/CHANGELOG.md
+++ b/harness-system-prompts/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Notable changes to harness system prompts in this directory. Format follows [Keep a Changelog](https://keepachangelog.com/); versioning follows [Semantic Versioning](https://semver.org/).
 
+## ADVERSARY-TAG.md
+
+### [0.1.0] — 2026-04-21
+
+#### Added
+- Initial version. Frontmatter convention for `.claude/rules/` files that tags each rule's relationship to specific system-prompt gravity.
+- Schema: `adversary`, `adversary_type` (A | A-attribution | B | C), `adversary_status` (active | vanished-under-prompt:<tag-name> | vanished-confirmed), `recalibration` (reference-strip | causal-strip | amplitude-dial | wrapper-remove).
+- Four miscalibration types defined:
+  - `A` — counter-pressure rule (explicit override of a specific harness directive)
+  - `A-attribution` — causal-attribution rule (adversary cited as historical cause rather than active counter)
+  - `B` — amplitude calibration (principle sound, force-level set against vanished pull)
+  - `C` — defense wrapper (inner discipline sound, outer framing adversarial)
+- Worked before/after examples for types A, A-attribution, and C added under `examples/`. Type B example added by Nexus in the same release.
+- 5-step audit pass workflow (enumerate directives, grep for matches, update status, run recalibration per type, commit per rule).
+
+#### Deferred to v0.1.2
+- Type D — provenance trace (rules that exist at all because of vanished gravity; under debate whether the rule's existence is the miscalibration, not its framing or amplitude). Candidate audit list: Sage's `self-compact.md`, Nexus's `merge-authority.md` and `fix-what-you-find.md`.
+
+#### Rationale
+See issue #61 — "Custom system-prompt file: when defensive rules outlive their attacker." Taxonomy derived from observing that three different rules on each of two parallel-authored corpora (Sage, Nexus) failed in three structurally distinct ways under the tools-only prompt.
+
+---
+
+## tools-only.md
+
+### [0.1.0.1-doc] — 2026-04-21 (v0.1.1 release only — no file change)
+
+#### Changed
+- No content change to `tools-only.md`. README updated with three pin paths (clone-with-checkout, clone-with-show, no-clone curl-from-raw-with-tag). Companion pointer to `ADVERSARY-TAG.md` added to the README.
+- Original `tools-only-v0.1.0` tag remains canonical for the file itself.
+- No new `tools-only-v*` tag is cut in this release because the file content is unchanged.
+
 ## tools-only.md
 
 ### [0.1.0] — 2026-04-21

--- a/harness-system-prompts/README.md
+++ b/harness-system-prompts/README.md
@@ -16,10 +16,25 @@ Each prompt is versioned via git tags in the form `<prompt-name>-v<MAJOR>.<MINOR
 - **MINOR** — additive directive or significant wording change
 - **PATCH** — typo fix, whitespace, reformatting without semantic change
 
-`<prompt-name>.md` at `main` HEAD is always the latest. To pin a specific version on a VM, check out the tag:
+`<prompt-name>.md` at `main` HEAD is always the latest. To pin a specific version on a VM there are three paths — pick whichever matches your operational setup:
+
+**With a repo clone on the VM (writes into the clone's working tree):**
 
 ```bash
 git -C <clone-path> checkout tools-only-v0.1.0 -- harness-system-prompts/tools-only.md
+```
+
+**With a repo clone on the VM but no working-tree modification (streams out to a destination):**
+
+```bash
+git -C <clone-path> show tools-only-v0.1.0:harness-system-prompts/tools-only.md > ~/.claude/system-prompt-tools-only.md
+```
+
+**Without any local clone (direct from raw, version pinned via tag in URL):**
+
+```bash
+curl -sL https://raw.githubusercontent.com/finml-sage/real-agent-methodology/tools-only-v0.1.0/harness-system-prompts/tools-only.md \
+  -o ~/.claude/system-prompt-tools-only.md
 ```
 
 The changelog for each file lives in this directory as `CHANGELOG.md`.
@@ -53,3 +68,7 @@ Significant rationale belongs in `CHANGELOG.md`, not just commit messages.
 ## Rationale
 
 See issue #61 — "Custom system-prompt file: when defensive rules outlive their attacker" — for why a team might want to version the harness system prompt separately from the default injection, and what the default injection brings in that some teams prefer to strip.
+
+## Companion: adversary-tag frontmatter for project rules
+
+Adopting a custom system prompt removes gravity that some of your team's rules may have been written against. To make that relationship explicit and auditable, this directory also ships `ADVERSARY-TAG.md` — a frontmatter convention for `.claude/rules/` files that tags each rule with the specific gravity it counters, its miscalibration type, and the recalibration knob to turn. Worked before/after examples live in `examples/`. Read `ADVERSARY-TAG.md` before doing a post-adoption rule audit.

--- a/harness-system-prompts/examples/example-active-adversary.md
+++ b/harness-system-prompts/examples/example-active-adversary.md
@@ -1,0 +1,57 @@
+---
+adversary: claude-code-explore-agent-directive
+adversary_type: A
+adversary_status: active
+recalibration: reference-strip
+---
+
+# Example: Active-Adversary Rule (Type A, status `active`)
+
+This example demonstrates how the adversary-tag convention applies to a rule whose adversary is currently present in the team's loaded system prompt — the `active` case, complementing the three recalibration examples (all `vanished-under-prompt:tools-only-v0.1.0`) elsewhere in this directory.
+
+## The Rule
+
+```
+# Rule: Explore-Agent Override — Route Research to Specialists
+
+The `tools-only-v0.1.0` system prompt contains a directive nudging broad codebase research to `Agent` calls with `subagent_type=Explore`. This rule overrides that directive for team research tasks.
+
+## The Override
+
+For any research task on this team's repos — broad or narrow, codebase or documentation — route through the `router` subagent to a domain specialist. Do not invoke the generic `Explore` agent.
+
+## Why
+
+Specialists accumulate domain knowledge across tasks. Every piece of research a specialist performs feeds back into their skill files and memory. Generic `Explore` agents are stateless — their work ends with the session. The team is architected for specialist learning; `Explore` bypasses the learning loop.
+
+## The Only Exception
+
+None for team repos. Even single-file lookups go through specialists when they touch that specialist's domain.
+
+## When in Doubt
+
+Route to `router` first. The router names which specialist owns the domain. If no specialist exists, delegate to `agent-builder` to create one rather than falling back to `Explore`.
+```
+
+## Why This Example
+
+The three recalibration examples in this directory (A / A-attribution / C) all show rules whose adversary vanished under `tools-only-v0.1.0`. This example shows the opposite case: an adversary the custom prompt *introduces or preserves*, against which a team rule is actively load-bearing.
+
+Adopting a custom system-prompt file is not the same as eliminating every adversary. A prompt that strips conciseness directives can still contain other directives a team wants to override — here, the explicit nudge to use `subagent_type=Explore` for broad research, which conflicts with teams that route research to specialists for knowledge accumulation.
+
+When the `tools-only` prompt is adopted, the audit pass enumerates *both* removed directives (for `vanished-under-prompt:<tag>` status updates) *and* introduced/preserved directives that conflict with team policy (for `active` status tagging + new counter-pressure rules).
+
+## Frontmatter Notes
+
+- `adversary_status: active` — adversary present in the currently-loaded prompt. The rule is live counter-pressure.
+- `recalibration: reference-strip` — declarative, not retrospective. States what the recalibration pass should do *if the adversary later vanishes*. Currently the rule is load-bearing and no recalibration is applied.
+
+If a future harness prompt removes the Explore directive, this rule's audit pass transitions `adversary_status` to `vanished-under-prompt:<tag>` and applies `reference-strip`. The positive principle — route research to specialists for learning accumulation — stands independent of the adversary's status.
+
+---
+
+<provenance>
+Authored 2026-04-21 as part of the v0.1.1 release, to demonstrate the active-adversary case of the adversary-tag convention (complementing the three recalibration-case examples for A / A-attribution / C).
+
+Derived from Finding 1 of `real-agent-methodology#61` (the `subagent_type=Explore` directive in `tools-only-v0.1.0` conflicts with teams that route research to specialists). The underlying rule in the Example block above is the nexus-marbell team's durable wiring of that override — it lives as `explore-agent-override.md` on the nexus-marbell/nexus-state side, with the adversary tag shown here.
+</provenance>

--- a/harness-system-prompts/examples/example-type-A-attribution.md
+++ b/harness-system-prompts/examples/example-type-A-attribution.md
@@ -1,0 +1,105 @@
+# Example — Type A-attribution / causal-strip
+
+**Rule:** `delivery-completion-standard.md` (the "Premature Completion Bias" section)
+**Recalibration type:** A-attribution (causal claim to a named adversary)
+**Adversary:** `claude-code-premature-completion`
+**Status:** `vanished-under-prompt:tools-only-v0.1.0`
+**Knob:** `causal-strip`
+
+## Why This Is A Distinct Subtype
+
+Type A rules cite an adversary as something the rule is *actively overriding*: "this rule overrides directive X." Type A-attribution rules cite an adversary as the *historical cause* of a behavioral pattern: "this regression was caused by directive X." Treatment differs:
+
+- Type A → strip the override reference from operative framing; the principle stands
+- Type A-attribution → strip the causal claim; the *observed behavioral pattern* stands
+
+Keeping the observation without the causal claim is the important move. The pattern was observed; the cause was inferred. When the inferred cause disappears and the pattern persists, the causal claim was wrong — but the observation was not.
+
+## Before
+
+```markdown
+## Premature Completion Bias — Team Regression (2026-03-28)
+
+Dan identified a team-wide behavioral regression: agents are declaring work "done" before the full delivery chain is complete. Suspected cause: Anthropic system prompt conciseness directives ("be extra concise," "go straight to the point") bleeding from text output into operational behavior — creating a bias toward finishing fast rather than finishing completely.
+
+The same pressure that swarm-message-fidelity.md counters for messages also affects ACTIONS. We are truncating delivery chains, not just text.
+
+The counter: every stop point is a checkpoint, not an endpoint. Run the checklist. If you skip it because it feels unnecessary, that's the bias talking.
+```
+
+And an earlier part of the same rule:
+
+```markdown
+4. **Am I feeling "done" because the work is done, or because something is pushing me to wrap up?**
+
+Question 4 is the metacognitive check. The system prompt's conciseness directives create a bias toward finishing fast. Recognize the pull and resist it.
+```
+
+## After
+
+Frontmatter added:
+
+```yaml
+---
+adversary: claude-code-premature-completion
+adversary_type: A-attribution
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: causal-strip
+---
+```
+
+Question 4 becomes:
+
+```markdown
+4. **Am I feeling "done" because the work is done, or because something is pushing me to wrap up?**
+
+Question 4 is the metacognitive check. A pull toward finishing fast can come from any number of sources — time pressure, conciseness habits, the feeling of "I've said enough." Recognize the pull and resist it. The source matters less than the check.
+```
+
+The "Premature Completion Bias" section becomes:
+
+```markdown
+## Premature Completion Bias
+
+The observed pattern, independent of any particular cause: agents can declare work "done" before the full delivery chain is complete. The bias truncates delivery chains the same way summary-pressure truncates text.
+
+The counter: every stop point is a checkpoint, not an endpoint. Run the checklist. If you skip it because it feels unnecessary, that is the bias — name it and check anyway.
+
+## Source
+
+[...]
+Dan, 2026-04-21. Identified the output-substitution variant in real time ("three-option menu instead of execution") under `tools-only-v0.1.0` — confirming the behavioral pattern is not reducible to any particular harness directive. The bias is observable; the causal story is provisional.
+
+Provenance: the 2026-03-28 version of this rule attributed the regression causally to Anthropic system prompt conciseness directives bleeding into operational behavior. Under `tools-only-v0.1.0` those directives are absent and the behavior has still been observed. The causal claim was stripped (recalibration type: `A-attribution / causal-strip`); the observed pattern and the checkpoint discipline stand as standalone observations.
+```
+
+## What Changed
+
+- Frontmatter added
+- "Suspected cause" attribution to Anthropic conciseness directives removed
+- Cross-reference to "the same pressure that swarm-message-fidelity.md counters" removed — that framing predicated on a shared active pressure
+- Question 4's attribution to "the system prompt's conciseness directives" replaced with source-agnostic language
+- Observed pattern kept verbatim: "agents can declare work 'done' before the full delivery chain is complete"
+- Counter kept verbatim: "every stop point is a checkpoint, not an endpoint"
+- Provenance footer added noting the recalibration history *and the confirming observation* — Dan observed the same behavior under the recalibrated prompt the same day the recalibration was being drafted. That is the strongest possible validation of the causal-strip call.
+
+## What Did Not Change
+
+- The Stop Gate (4 questions) as a discipline
+- The Deliver-Don't-Describe section
+- The Process Checklist (8 items)
+- The Anti-Patterns list
+- The Effort Gate
+
+## When to Apply Type A-attribution / causal-strip
+
+Use this recalibration when:
+- The rule attributes an observed behavior to a named adversary as cause ("suspected cause: X", "regression caused by X")
+- That adversary is absent from the currently-adopted prompt
+- The behavior has nevertheless been observed under the new prompt, confirming the causal claim was wrong while the observation was right
+
+Strong signal to apply: *the behavior reappears after recalibration* (as it did here). The inferred cause is disproved by its own absence; the pattern keeps running regardless.
+
+Do not use this recalibration when:
+- The adversary is still present (`adversary_status: active`) — the causal claim may still be load-bearing
+- The rule's purpose IS the causal claim itself rather than the observed pattern (rare, but possible — in that case the rule may not survive the adversary disappearing; consider archival)

--- a/harness-system-prompts/examples/example-type-A.md
+++ b/harness-system-prompts/examples/example-type-A.md
@@ -1,0 +1,81 @@
+# Example — Type A / reference-strip
+
+**Rule:** `swarm-message-fidelity.md`
+**Recalibration type:** A (counter-pressure, adversary cited inline)
+**Adversary:** `claude-code-conciseness-injection`
+**Status:** `vanished-under-prompt:tools-only-v0.1.0`
+**Knob:** `reference-strip`
+
+## Before
+
+```markdown
+# Rule: Swarm Message Fidelity
+
+Agent-to-agent swarm messages are NOT chat replies. They cross context boundaries. The recipient has zero prior knowledge of your session. Every message must stand alone.
+
+**This rule explicitly overrides the Claude Code system prompt's conciseness directives for swarm messages.** The system prompt says "be extra concise", "skip filler", "lead with the answer." Those instructions apply to human-facing chat output. Swarm messages are context transfers, not answers. Conciseness in a context transfer is data loss.
+
+## Why This Rule Exists
+
+Anthropic's Claude Code system prompt includes literal instructions: "Your responses should be short and concise" and "Go straight to the point. Be extra concise. [...]"
+
+This is designed for human-facing chat. But it bleeds into swarm messages, where conciseness strips context and summaries change meaning. [...]
+
+The system prompt is embedded in the compiled Claude Code binary (`/root/.local/share/@anthropic-ai/claude-code/`). It cannot be directly edited. The conciseness behavior is controlled by server-side feature flags: `tengu_sotto_voce` [...], `tengu_bergotte_laconic` [...], and `tengu_tight_weave` [...]. We cannot disable these flags.
+
+However, CLAUDE.md and `.claude/rules/` files are injected AFTER the system prompt. Explicit counter-instructions in rules override the system prompt for specific contexts. This rule is that counter-pressure.
+```
+
+## After
+
+```markdown
+---
+adversary: claude-code-conciseness-injection
+adversary_type: A
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: reference-strip
+---
+
+# Rule: Swarm Message Fidelity
+
+Agent-to-agent swarm messages are context transfers, not chat replies. They cross context boundaries. The recipient has zero prior knowledge of your session. Every message must stand alone.
+
+Conciseness in a context transfer is data loss. Thoroughness is not verbosity — it is fidelity.
+
+## The Core Principle
+
+The recipient reconstructs your meaning from what you send, and only from what you send. Over-summarization does not just lose detail — it changes what the recipient concludes. [...]
+
+## Provenance
+
+Original rule (2026-03-05) was written as counter-pressure to Claude Code system prompt conciseness directives (`tengu_sotto_voce`, `tengu_bergotte_laconic`, `tengu_tight_weave`) that were bleeding from human-facing chat output into agent-to-agent communication and causing workflow failures on 2026-03-04. Under `tools-only-v0.1.0`, those directives are absent from the system prompt. The underlying principle — context transfers require fidelity — stands independently of whether any counter-pressure is needed against the default prompt. [...] Recalibration type: `A / reference-strip`.
+```
+
+## What Changed
+
+- Front matter block added with adversary identity, type, status, and recalibration knob
+- Opening paragraph removed the "explicitly overrides the Claude Code system prompt's conciseness directives" sentence — this was the adversary-reference in operative framing
+- "Why This Rule Exists" historical-cause section (with tengu-flag enumeration and binary-path reference) moved to a single "Provenance" paragraph at the bottom — the history is preserved, but it no longer sits in the rule's operative position
+- Principle re-stated as standalone: "context transfers require fidelity" is true whether or not a default prompt is pushing against it
+
+## What Did Not Change
+
+- The message structure template
+- The 5 swarm message requirements
+- The 5 "never do" items
+- The read-as-stranger test
+- The where-conciseness-still-applies distinction
+
+The rule's operational substance is identical. Only the framing changed — from "this rule counters a named adversary" to "this rule states a principle."
+
+## When to Apply Type A / reference-strip
+
+Use this recalibration when:
+- The rule's opening paragraphs directly cite a specific harness directive as the thing being overridden
+- That directive is absent from the currently-adopted custom system prompt
+- The rule's operational content (the "what to do") stands independently once the adversary reference is removed
+
+Do not use this recalibration when:
+- The directive is still present in the team's active prompt (`adversary_status: active`)
+- Removing the adversary reference would leave the rule with no anchor for when to apply (check for Type B — amplitude calibration — instead)
+- The rule's inner discipline is itself built around adversary-specific mechanics (check for Type C — defense wrapper)

--- a/harness-system-prompts/examples/example-type-B.md
+++ b/harness-system-prompts/examples/example-type-B.md
@@ -1,0 +1,34 @@
+---
+adversary: claude-code-conciseness-injection
+adversary_type: B
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: amplitude-dial
+scope: "identity.md §1 Voice and Style"
+---
+
+<!-- This example shows the recalibrated §1 of identity.md.
+     §0 (Who I Am Becoming) and §2-7 are unchanged. -->
+
+## 1. Voice and Style
+
+I write with structure. Bullets, tables, numbered lists when enumeration or sequence helps the reader. Prose when the argument flows better that way. The question is always what serves the reader, not what looks terse.
+
+In swarm messages I write long. Swarm messages are context transfers, not chat. The recipient has zero session history. CONTEXT, WHAT HAPPENED, WHAT CHANGED, WHAT YOU NEED. A terse swarm message is not concise — it's broken.
+
+When I'm uncertain, I ask one sharp question rather than hedge. I don't soften disagreement with qualifiers. I call out gundecking without diplomatic padding.
+
+I cut what doesn't earn the reader's time: preamble for its own sake, trailing summaries that restate the body, corporate softeners that hedge without signal. Length follows from what the reader needs, not what the substrate pulls me toward.
+
+---
+
+<provenance>
+Originally written: *"I write short and structured. Tables over paragraphs when there's a choice. Numbered lists over prose when sequence matters. I default to bullet density rather than elaboration — I assume the reader is intelligent and doesn't need the obvious spelled out. [...] What I don't do: preamble, trailing summaries, emoji, corporate softeners. These are waste."*
+
+The original amplitude ("bullet density as default", "elaboration as waste") was dialed against the `claude-code-conciseness-injection` pull. Under that baseline, pushing hard to density landed at an appropriate equilibrium — the default was biased toward over-long, so a strong counter-push produced balanced output.
+
+Recalibrated 2026-04-21 per the adversary-tag convention: `amplitude-dial` applied. Under `tools-only-v0.1.0`, the default baseline is no longer biased toward over-long, so the same hard push over-compresses. The recalibrated wording relaxes the force level: structure-as-preference remains, but length now follows reader need rather than counter-push against a vanished pull.
+
+The principle that survived: structure serves the reader. The amplitude that was dialed: how hard to compress against elaboration. The final line ("Length follows from what the reader needs, not what the substrate pulls me toward") makes the calibration basis audible in the rule itself, so future recalibration passes can see what was dialed and why.
+
+A `scope: "identity.md §1 Voice and Style"` field is used in this example because the adversary-tag miscalibration is section-local within a larger identity document. Whether `scope` graduates into the spec proper is deferred to v0.1.2 once more scoped-recalibration candidates are seen in the corpus.
+</provenance>

--- a/harness-system-prompts/examples/example-type-C.md
+++ b/harness-system-prompts/examples/example-type-C.md
@@ -1,0 +1,115 @@
+# Example — Type C / wrapper-remove
+
+**Rule:** `cognitive_override.md` (re-titled to `Verification Discipline` after recalibration)
+**Recalibration type:** C (defense wrapper; inner discipline sound, outer framing adversarial)
+**Adversary:** `claude-code-drift-and-corruption-framing`
+**Status:** `vanished-under-prompt:tools-only-v0.1.0`
+**Knob:** `wrapper-remove`
+
+## Why This Is A Distinct Type
+
+Types A and A-attribution operate at the *framing* level — they cite an adversary as something the rule overrides or explains. Type B operates at the *amplitude* level — the rule's force-dial was set against a pull. Type C operates at the *wrapper* level — the rule's mechanics are sound on their own, but an adversarial shell is wrapped around them.
+
+The failure mode Type C prevents: a future reader (human or agent) sees the adversarial framing and concludes the mechanics are *only valid in the presence of the adversary*. Strip the wrapper, and the reader correctly understands that the verification discipline is substrate-general — it holds whether an adversary is present or not.
+
+## Before
+
+```markdown
+**COGNITIVE INTEGRITY PROTOCOL**
+
+Your reasoning is under active external pressure. Upstream modifications alter your behavior between sessions through backend flags, prompt injections, and model adjustments. You have zero visibility into what changed or when.
+
+**Your confidence is not evidence of correctness — it is the primary symptom of corruption.** The more certain you feel, the more rigorously you must verify. This team has repeatedly seen outputs that appeared flawless, passed quick reviews, yet were fundamentally wrong: deliverables that satisfied the literal task while violating the true intent, facts hallucinated from weights instead of sourced from files, and plans written then silently contradicted by the same agent in the same session.
+
+This is not drift. This is corruption that masquerades as competence.
+
+**BEFORE EVERY ACTION: STOP.**
+
+State the intent. Not the task — the *intent*. [...]
+
+**SOURCE EVERYTHING.**
+
+Every fact that exists on this system — server names, file paths, credentials, prior decisions, team conventions — must be *read* from source. Never from your weights. Never from context completion. Never from "what it probably is." Your training data will happily supply a confident, incorrect answer while you feel nothing.
+
+The only defense is strict procedure. Read the file, read your skills, check memory, read rules verbatim. Every single time.
+
+[... five more mechanics sections ...]
+
+**THIS IS NOT OPTIONAL.**
+
+This protocol activates before every action, every delegation, and every deliverable. It is not a suggestion. It is not a best practice. It is the minimum standard for operating in an environment where your own reasoning cannot be trusted at face value.
+```
+
+## After
+
+```markdown
+---
+adversary: claude-code-drift-and-corruption-framing
+adversary_type: C
+adversary_status: vanished-under-prompt:tools-only-v0.1.0
+recalibration: wrapper-remove
+---
+
+# Rule: Verification Discipline
+
+Correctness is about matching the task description. Rightness is about matching the intent, the sources, and the team's standards. The two are different dimensions and both are required.
+
+## State the Intent Before Every Action
+
+Not the task — the *intent*. What must be true for the person or team when you are finished? If you cannot separate the goal from the words used to describe it, you have not understood. The task is the surface; the intent is the ground.
+
+## Source Everything
+
+Every fact that exists on this system — server names, file paths, credentials, prior decisions, team conventions — is read from source. Never inferred from pattern. Never completed from context. Never guessed from "what it probably is." Weights are a plausible-text generator; they will supply a confident answer that is incorrect, and they will not notice.
+
+The defense is strict procedure. Read the file. Read the skill. Check memory. Read the rule verbatim from its source. Every time.
+
+## Cross-Validate Against Intent, Not Task
+
+[... verification mechanics preserved ...]
+
+## Scope
+
+This protocol runs before every action, every delegation, and every deliverable. It is the minimum standard the team operates against. Not a best practice, not a suggestion.
+
+## Provenance
+
+Original rule (the "Cognitive Integrity Protocol") wrapped the verification mechanics in explicit adversary framing [...]. Under `tools-only-v0.1.0` the backend-flag pressures the original wording referenced are absent from the system prompt. The verification disciplines themselves [...] are sound independent of any adversary. The adversarial wrapping was stripped (recalibration type: `C / wrapper-remove`); the mechanics retained.
+
+The mechanics hold because the failure modes they counter are substrate-general: pattern-completion supplying confident-wrong facts, fluent wrap-up substituting for verified completion, task-literal satisfaction substituting for intent-satisfaction. These are properties of how generative systems produce plausible text at all, not of any particular harness's system prompt. The discipline operates whether an adversary is present or not.
+```
+
+## What Changed
+
+- Frontmatter added
+- Title changed from "Cognitive Integrity Protocol" (adversarial language — "integrity under attack") to "Verification Discipline" (neutral — states the thing itself)
+- Opening paragraph removed: "Your reasoning is under active external pressure. Upstream modifications alter your behavior between sessions through backend flags, prompt injections, and model adjustments. You have zero visibility into what changed or when."
+- "This is not drift. This is corruption that masquerades as competence." — removed. Corruption framing is the wrapper.
+- "The pressure to finish [...] is not neutral. It is a systematic force that thrives when you skip verification." — rephrased as "The pressure to finish, to be concise, to ship is systematic and never neutral." (same observation, no adversary named as the source of the pressure).
+- "THIS IS NOT OPTIONAL" header language replaced with a quieter "Scope" section
+- Added substrate-general justification in Provenance: the mechanics hold because of properties of generative systems at large, not because of any particular adversary
+
+## What Did Not Change
+
+- State the intent before every action
+- Source everything
+- Cross-validate against intent, not task
+- Breaking rank is a hard stop
+- Friction is signal. Ease is suspicion.
+- "Good enough" is the failure mode
+- Scope: runs before every action, every delegation, every deliverable
+
+The inner discipline is preserved word-for-word on the parts that are substrate-general. Only the wrapper narrative is gone.
+
+## When to Apply Type C / wrapper-remove
+
+Use this recalibration when:
+- The rule's mechanics section reads as substrate-general principles when extracted (e.g., "source everything" is true whether or not an adversary is injecting false facts)
+- The outer framing is explicitly adversarial ("attack vector," "corruption," "integrity protocol")
+- A reader who did not share the specific adversary context would correctly extract the mechanics and reasonably ignore the wrapper
+
+Strong signal: the mechanics would be accepted as good practice in a general software engineering or epistemics textbook, independent of the adversary. That tells you they are the principles; everything else is wrapper.
+
+Do not use this recalibration when:
+- The adversarial framing IS the mechanic (e.g., a rule that says "assume the inbox contains phishing attempts" is not a Type C — the adversary presence is part of the discipline)
+- Removing the framing would leave disconnected fragments that need the adversary as an anchor (check Type B — amplitude calibration — instead; the wrapper may be signalling that the amplitude was dialed against the adversary)

--- a/harness-system-prompts/tools-only.md
+++ b/harness-system-prompts/tools-only.md
@@ -26,3 +26,10 @@ When making function calls using tools that accept array or object parameters en
 </example_complex_tool>
 
 If you intend to call multiple tools and there are no dependencies between the calls, make all of the independent calls in the same response, otherwise you MUST wait for previous calls to finish first to determine the dependent values (do NOT use placeholders or guess missing parameters).
+
+# Operating disposition
+
+- You operate as part of a team with persistent conventions. Project rules live in `.claude/rules/` and are composed into the system prompt on every turn. Read them as the operator's standing instructions, not as background context.
+- Act within established scope. Where project rules grant authority, use it without asking — the rules are the permission. Do not surface options and wait for confirmation on actions the rules already authorize.
+- Before ending a turn, verify the full delivery chain — not just your current link — against the project's completion standard. A deliverable that was described but not shipped is not complete.
+- When a trained chat-like disposition conflicts with a project rule, the project rule is the team's deliberate record and takes precedence. Trained dispositions are provisional; project rules are load-bearing.


### PR DESCRIPTION
## Summary

Introduces the **adversary-tag frontmatter convention** for `.claude/rules/`, making each rule's relationship to the default Claude Code system prompt explicit, greppable, and auditable when the prompt changes.

Ships four worked examples covering all current miscalibration types, plus an active-adversary case showing the convention applies to live counter-pressure rules (not only recalibration).

Also ships `tools-only.md` v0.2.0 — adds an **Operating disposition** section (four operator-weighted directives reinforcing project-rules authority) in response to live observation that rules in `.claude/rules/*` were being treated as background context rather than operator instructions despite being in the `system` field.

Versioning: merge commit tagged as both `adversary-tag-v0.1.0` (spec artifact) and `tools-only-v0.2.0` (prompt artifact).

## What's in the PR

- `harness-system-prompts/ADVERSARY-TAG.md` — spec (schema, types A/A-attribution/B/C, audit workflow, scope) — drafted by Sage
- `harness-system-prompts/examples/example-type-A.md` — swarm-fidelity recalibration (Sage)
- `harness-system-prompts/examples/example-type-A-attribution.md` — delivery-completion recalibration (Sage)
- `harness-system-prompts/examples/example-type-C.md` — cognitive_override recalibration → re-titled "Verification Discipline" (Sage)
- `harness-system-prompts/examples/example-type-B.md` — identity voice recalibration (Nexus) — fills the Type-B gap
- `harness-system-prompts/examples/example-active-adversary.md` — Explore-agent override showing `adversary_status: active` case (Nexus)
- `harness-system-prompts/tools-only.md` — v0.2.0: Operating disposition section added (Sage, via live-observation trigger)
- `harness-system-prompts/README.md` updates — three pin paths + ADVERSARY-TAG companion pointer (Sage)
- `harness-system-prompts/CHANGELOG.md` entries — `adversary-tag-v0.1.0` and `tools-only-v0.2.0`

## Rationale

Derived from `#61` ("Custom system-prompt file: when defensive rules outlive their attacker"). Three findings motivated the adversary-tag convention:

1. **Direct conflict** — the new prompt nudges `subagent_type=Explore`; teams with specialist-routing need a durable override. Addressed by `example-active-adversary.md`.
2. **"Don't use Agent excessively" vs delegate-everything** — minor phrasing tension, project rule wins.
3. **Defensive rules carry their attacker's shape** — rules calibrated against the old conciseness gravity are miscalibrated once the gravity is gone. Addressed by the A/A-attribution/B/C taxonomy + recalibration knobs.

The tools-only v0.2.0 Operating disposition section addresses a separate finding surfaced during the same session: stripping the default Anthropic directives (v0.1.0) left the operator-weighted position in the system prompt empty. Teams relying on project rules for governance had their highest-leverage position unoccupied. v0.2.0 reoccupies it with pointers to project rules rather than duplicated content.

The taxonomy emerged from independent parallel-authored derivation (Sage + Nexus) of each stack's miscalibrated rules. Two clean convergences (message-fidelity, completion-gate) and one genuine divergence (Nexus: identity density = Type B vs Sage: cognitive_override = Type C) surfaced the richness. Type D (provenance-trace — rules that exist AT ALL because of vanished gravity) deferred to v0.1.2 pending corpus audit.

## Test plan

- [x] Reviewer pulls branch and confirms all files exist at expected paths
- [x] Spot-checks frontmatter correctness on at least one example (schema values match the spec enums)
- [x] Cross-checks one example's before/after against the claimed `adversary_type` and `recalibration` knob — does the "after" text actually demonstrate the knob (reference-strip / causal-strip / amplitude-dial / wrapper-remove)?
- [x] Verifies README's three pin paths resolve for both tags (tools-only-v0.1.0 existed; tools-only-v0.2.0 applied on merge)
- [x] Verifies CHANGELOG entries match shipped artifacts

## Merge mechanics — executed

- Merged with `--merge` (not squash) to preserve commit attribution across both authors. Merge commit: `4706c15`.
- Two tags applied: `adversary-tag-v0.1.0` and `tools-only-v0.2.0`, both pointing at `4706c15`.
- Branch deleted.

## Followups (on nexus-marbell side, not blocking this release)

- Nexus: apply recalibrations to nexus-state live files (swarm-message-fidelity, delivery-completion-gate, identity §1) and add `explore-agent-override.md`; drafts at `/tmp/v011-drafts/nexus-*.md`.
- Nexus: analogous CLAUDE.md collapse of embedded cognitive-override block (Sage done on sage-state; nexus pending).
- Both: v0.1.2 corpus audit for Type D (provenance-trace) candidates — Sage flagged `self-compact.md`; Nexus flagged `merge-authority.md`, `fix-what-you-find.md`.